### PR TITLE
Django 1.8+ support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,13 @@
 language: python
 
 python:
-    - 2.6
     - 2.7
 
 sudo: false
 
 env:
-    - DJANGO=1.4.16
-    - DJANGO=1.5.11
-    - DJANGO=1.6.8
-    - DJANGO=1.7.1
-
-matrix:
-    exclude:
-        - python: 2.6
-          env: DJANGO=1.7.1
+    - DJANGO=1.8.7
+    - DJANGO=1.9
 
 before_install:
     - bash bin/check_signoff.sh

--- a/modeltree/__init__.py
+++ b/modeltree/__init__.py
@@ -1,8 +1,8 @@
 __version_info__ = {
-    'major': 1,
-    'minor': 2,
+    'major': 2,
+    'minor': 0,
     'micro': 0,
-    'releaselevel': 'beta',
+    'releaselevel': 'alpha',
     'serial': 1
 }
 

--- a/modeltree/compat.py
+++ b/modeltree/compat.py
@@ -1,6 +1,0 @@
-try:
-    # Django 1.5+
-    from django.db.models.constants import LOOKUP_SEP
-except ImportError:
-    # Django <= 1.4
-    from django.db.models.sql.constants import LOOKUP_SEP  # noqa

--- a/modeltree/managers.py
+++ b/modeltree/managers.py
@@ -1,4 +1,3 @@
-import django
 from django.db import models
 from modeltree.query import ModelTreeQuerySet
 
@@ -8,11 +7,8 @@ class ModelTreeManager(models.Manager):
         super(ModelTreeManager, self).__init__(*args, **kwargs)
         self.tree = tree or self.model
 
-    def get_query_set(self):
+    def get_queryset(self):
         return ModelTreeQuerySet(model=self.tree, using=self.db)
 
     def select(self, *args, **kwargs):
-        if django.VERSION < (1, 6):
-            return self.get_query_set().select(*args, **kwargs)
-
         return self.get_queryset().select(*args, **kwargs)

--- a/modeltree/tree.py
+++ b/modeltree/tree.py
@@ -607,7 +607,7 @@ class ModelTree(object):
         """
         field = rel.field
         if isinstance(field, models.OneToOneField):
-            if self._join_allowed(rel.parent_model, rel.model, field):
+            if self._join_allowed(rel.model, rel.related_model, field):
                 return rel
 
     def _filter_fk(self, field):
@@ -628,7 +628,7 @@ class ModelTree(object):
         """
         field = rel.field
         if isinstance(field, models.ForeignKey):
-            if self._join_allowed(rel.parent_model, rel.model, field):
+            if self._join_allowed(rel.model, rel.related_model, field):
                 return rel
 
     def _filter_m2m(self, field):
@@ -649,7 +649,7 @@ class ModelTree(object):
         """
         field = rel.field
         if isinstance(field, models.ManyToManyField):
-            if self._join_allowed(rel.parent_model, rel.model, field):
+            if self._join_allowed(rel.model, rel.related_model, field):
                 return rel
 
     def _add_node(self, parent, model, relation, reverse, related_name,

--- a/modeltree/tree.py
+++ b/modeltree/tree.py
@@ -578,13 +578,14 @@ class ModelTree(object):
         forward_fields = [
             f for f in fields
             if (f.one_to_one or f.many_to_many or f.many_to_one)
-            and not f.auto_created
+            and (f.concrete or not f.auto_created)
+            and f.rel is not None  # Generic foreign keys do not define rel.
             and self._join_allowed(f.model, f.rel.to, f)
         ]
         reverse_fields = [
             f for f in fields
             if (f.one_to_many or f.one_to_one or f.many_to_many)
-            and f.auto_created
+            and (not f.concrete and f.auto_created)
             and self._join_allowed(f.model, f.related_model, f.field)
         ]
 

--- a/modeltree/tree.py
+++ b/modeltree/tree.py
@@ -706,7 +706,10 @@ class ModelTree(object):
 
         # determine relational fields to determine paths
         forward_fields = opts.fields
-        reverse_fields = opts.get_all_related_objects()
+        reverse_fields = [
+            f for f in model._meta.get_fields()
+            if (f.one_to_many or f.one_to_one) and f.auto_created
+        ]
 
         forward_o2o = filter(self._filter_one2one, forward_fields)
         reverse_o2o = filter(self._filter_related_one2one, reverse_fields)

--- a/modeltree/utils.py
+++ b/modeltree/utils.py
@@ -1,9 +1,9 @@
 import sys
 from django.db import models
 from django.db.models import FieldDoesNotExist
+from django.db.models.constants import LOOKUP_SEP
 from django.db.models.sql.constants import QUERY_TERMS
 from django.utils.termcolors import colorize
-from modeltree.compat import LOOKUP_SEP
 from modeltree.tree import trees, ModelDoesNotExist, ModelNotRelated, \
     ModelNotUnique
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ kwargs = {
     'include_package_data': True,
 
     # Dependencies
-    'install_requires': ['django>=1.4,<1.8'],
+    'install_requires': ['django>=1.8,<1.10'],
 
     'test_suite': 'test_suite',
 

--- a/test_suite.py
+++ b/test_suite.py
@@ -6,18 +6,11 @@ os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.settings'
 import django
 from django.core import management
 
-if django.VERSION >= (1, 7):
-    django.setup()
+django.setup()
 
 apps = sys.argv[1:]
 
-# Django 1.6 and beyond require the full path to the test modules while
-# Django 1.5 and earlier could get by with just the module name so we inject
-# a prefix if the Django version is 1.6 or higher.
-if django.VERSION < (1, 6):
-    prefix = ''
-else:
-    prefix = 'tests.cases.'
+prefix = 'tests.cases.'
 
 if not apps:
     apps = [

--- a/test_suite.py
+++ b/test_suite.py
@@ -16,6 +16,7 @@ if not apps:
     apps = [
         prefix + 'core',
         prefix + 'proxy',
+        prefix + 'generic',
         prefix + 'regressions',
     ]
 

--- a/tests/cases/core/tests/test_query.py
+++ b/tests/cases/core/tests/test_query.py
@@ -36,10 +36,10 @@ class ModelTreeQuerySetTestCase(TestCase):
             '("tests_title"."salary" < 50000 )'.replace(' ', ''))
 
     def test_select(self):
-        location = models.Office._meta.get_field_by_name('location')[0]
-        salary = models.Title._meta.get_field_by_name('salary')[0]
-        name = models.Project._meta.get_field_by_name('name')[0]
-        start_time = models.Meeting._meta.get_field_by_name('start_time')[0]
+        location = models.Office._meta.get_field('location')
+        salary = models.Title._meta.get_field('salary')
+        name = models.Project._meta.get_field('name')
+        start_time = models.Meeting._meta.get_field('start_time')
 
         qs = models.Employee.branches.select(
             location, salary, name, start_time)

--- a/tests/cases/core/tests/test_tree.py
+++ b/tests/cases/core/tests/test_tree.py
@@ -1,4 +1,3 @@
-import django
 from django.conf import settings
 from django.test import TestCase
 from modeltree.tree import trees, LazyModelTrees

--- a/tests/cases/core/tests/test_tree.py
+++ b/tests/cases/core/tests/test_tree.py
@@ -7,10 +7,6 @@ from tests import models
 __all__ = ('LazyTreesTestCase', 'ModelTreeTestCase')
 
 
-get_join_type = lambda: django.VERSION < (1, 5) and 'INNER JOIN' \
-    or 'LEFT OUTER JOIN'
-
-
 class LazyTreesTestCase(TestCase):
     def test(self):
         # Manually initialize to prevent conflicting state with other tests
@@ -129,10 +125,9 @@ class ModelTreeTestCase(TestCase):
             str(title_qs.query).replace(' ', ''),
             'SELECT "tests_office"."id", "tests_office"."location" FROM '
             '"tests_office" LEFT OUTER JOIN "tests_employee" ON '
-            '("tests_office"."id" = "tests_employee"."office_id") {join} '
-            '"tests_title" ON ("tests_employee"."title_id" = '
+            '("tests_office"."id" = "tests_employee"."office_id") LEFT OUTER '
+            'JOIN "tests_title" ON ("tests_employee"."title_id" = '
             '"tests_title"."id")'
-            .format(join=get_join_type())
             .replace(' ', ''))
 
         employee_qs, alias = self.office_mt.add_joins(models.Employee)
@@ -171,9 +166,8 @@ class ModelTreeTestCase(TestCase):
             'SELECT "tests_title"."id", "tests_title"."name", '
             '"tests_title"."salary" FROM "tests_title" LEFT OUTER JOIN '
             '"tests_employee" ON ("tests_title"."id" = '
-            '"tests_employee"."title_id") {join} "tests_office" ON '
+            '"tests_employee"."title_id") LEFT OUTER JOIN "tests_office" ON '
             '("tests_employee"."office_id" = "tests_office"."id")'
-            .format(join=get_join_type())
             .replace(' ', ''))
 
         employee_qs, alias = self.title_mt.add_joins(models.Employee)
@@ -270,9 +264,8 @@ class ModelTreeTestCase(TestCase):
             '("tests_project"."id" = "tests_project_employees"."project_id") '
             'LEFT OUTER JOIN "tests_employee" ON '
             '("tests_project_employees"."employee_id" = '
-            '"tests_employee"."id") {join} "tests_title" ON '
+            '"tests_employee"."id") LEFT OUTER JOIN "tests_title" ON '
             '("tests_employee"."title_id" = "tests_title"."id")'
-            .format(join=get_join_type())
             .replace(' ', ''))
 
         office_qs, alias = self.project_mt.add_joins(models.Office)
@@ -284,9 +277,8 @@ class ModelTreeTestCase(TestCase):
             '("tests_project"."id" = "tests_project_employees"."project_id") '
             'LEFT OUTER JOIN "tests_employee" ON '
             '("tests_project_employees"."employee_id" = '
-            '"tests_employee"."id") {join} "tests_office" ON '
+            '"tests_employee"."id") LEFT OUTER JOIN "tests_office" ON '
             '("tests_employee"."office_id" = "tests_office"."id")'
-            .format(join=get_join_type())
             .replace(' ', ''))
 
         employee_qs, alias = self.project_mt.add_joins(models.Employee)
@@ -321,9 +313,8 @@ class ModelTreeTestCase(TestCase):
             '"tests_meeting_attendees" ON ("tests_meeting"."id" = '
             '"tests_meeting_attendees"."meeting_id") LEFT OUTER JOIN '
             '"tests_employee" ON ("tests_meeting_attendees"."employee_id" = '
-            '"tests_employee"."id") {join} "tests_title" ON '
+            '"tests_employee"."id") LEFT OUTER JOIN "tests_title" ON '
             '("tests_employee"."title_id" = "tests_title"."id")'
-            .format(join=get_join_type())
             .replace(' ', ''))
 
         office_qs, alias = self.meeting_mt.add_joins(models.Office)
@@ -380,14 +371,13 @@ class ModelTreeTestCase(TestCase):
             '"tests_title"."salary", "tests_project"."name", '
             '"tests_meeting"."start_time" FROM "tests_office" LEFT OUTER '
             'JOIN "tests_employee" ON ("tests_office"."id" = '
-            '"tests_employee"."office_id") {join} "tests_title" ON '
+            '"tests_employee"."office_id") LEFT OUTER JOIN "tests_title" ON '
             '("tests_employee"."title_id" = "tests_title"."id") LEFT OUTER '
             'JOIN "tests_project_employees" ON ("tests_employee"."id" = '
             '"tests_project_employees"."employee_id") LEFT OUTER JOIN '
             '"tests_project" ON ("tests_project_employees"."project_id" = '
             '"tests_project"."id") LEFT OUTER JOIN "tests_meeting" ON '
             '("tests_office"."id" = "tests_meeting"."office_id")'
-            .format(join=get_join_type())
             .replace(' ', ''))
 
         qs = self.title_mt.add_select(*fields)
@@ -397,7 +387,7 @@ class ModelTreeTestCase(TestCase):
             '"tests_title"."salary", "tests_project"."name", '
             '"tests_meeting"."start_time" FROM "tests_title" LEFT OUTER JOIN '
             '"tests_employee" ON ("tests_title"."id" = '
-            '"tests_employee"."title_id") {join} "tests_office" ON '
+            '"tests_employee"."title_id") LEFT OUTER JOIN "tests_office" ON '
             '("tests_employee"."office_id" = "tests_office"."id") LEFT OUTER '
             'JOIN "tests_project_employees" ON ("tests_employee"."id" = '
             '"tests_project_employees"."employee_id") LEFT OUTER JOIN '
@@ -407,7 +397,6 @@ class ModelTreeTestCase(TestCase):
             '"tests_meeting_attendees"."employee_id") LEFT OUTER JOIN '
             '"tests_meeting" ON ("tests_meeting_attendees"."meeting_id" = '
             '"tests_meeting"."id")'
-            .format(join=get_join_type())
             .replace(' ', ''))
 
         qs = self.employee_mt.add_select(*fields)
@@ -438,12 +427,11 @@ class ModelTreeTestCase(TestCase):
             'JOIN "tests_project_employees" ON ("tests_project"."id" = '
             '"tests_project_employees"."project_id") LEFT OUTER JOIN '
             '"tests_employee" ON ("tests_project_employees"."employee_id" = '
-            '"tests_employee"."id") {join} "tests_office" ON '
-            '("tests_employee"."office_id" = "tests_office"."id") {join} '
-            '"tests_title" ON ("tests_employee"."title_id" = '
+            '"tests_employee"."id") LEFT OUTER JOIN "tests_office" ON '
+            '("tests_employee"."office_id" = "tests_office"."id") LEFT OUTER '
+            'JOIN "tests_title" ON ("tests_employee"."title_id" = '
             '"tests_title"."id") LEFT OUTER JOIN "tests_meeting" ON '
             '("tests_project"."id" = "tests_meeting"."project_id")'
-            .format(join=get_join_type())
             .replace(' ', ''))
 
         qs = self.meeting_mt.add_select(*fields)
@@ -457,9 +445,8 @@ class ModelTreeTestCase(TestCase):
             'ON ("tests_meeting"."id" = '
             '"tests_meeting_attendees"."meeting_id") LEFT OUTER JOIN '
             '"tests_employee" ON ("tests_meeting_attendees"."employee_id" = '
-            '"tests_employee"."id") {join} "tests_title" ON '
+            '"tests_employee"."id") LEFT OUTER JOIN "tests_title" ON '
             '("tests_employee"."title_id" = "tests_title"."id") LEFT OUTER '
             'JOIN "tests_project" ON ("tests_meeting"."project_id" = '
             '"tests_project"."id")'
-            .format(join=get_join_type())
             .replace(' ', ''))

--- a/tests/cases/generic/models.py
+++ b/tests/cases/generic/models.py
@@ -1,0 +1,10 @@
+from django.contrib.contenttypes.fields import GenericForeignKey
+from django.db import models
+
+
+class GenericModel(models.Model):
+    content_type = models.ForeignKey(
+        'contenttypes.ContentType', blank=True, null=True)
+    object_id = models.PositiveIntegerField(
+        db_index=True, blank=True, null=True)
+    reference_object = GenericForeignKey('content_type', 'object_id')

--- a/tests/cases/generic/tests.py
+++ b/tests/cases/generic/tests.py
@@ -1,0 +1,14 @@
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+from modeltree.tree import ModelTree
+
+
+class ProxyModelTestCase(TestCase):
+    def setUp(self):
+        self.tree = ModelTree(model='generic.GenericModel')
+
+    def test_content_type_fk(self):
+        f = ContentType._meta.pk
+
+        qs = self.tree.query_string_for_field(f)
+        self.assertEqual(qs, 'content_type__id')

--- a/tests/cases/proxy/models.py
+++ b/tests/cases/proxy/models.py
@@ -1,8 +1,14 @@
 from django.db import models
 
 
-class Target(models.Model):
+class OtherModel(models.Model):
     pass
+
+
+class Target(models.Model):
+    other_model = models.OneToOneField(OtherModel)
+    m2m = models.ManyToManyField(OtherModel)
+    fk = models.ForeignKey(OtherModel)
 
 
 class TargetProxy(Target):
@@ -10,6 +16,12 @@ class TargetProxy(Target):
         proxy = True
 
 
+class TargetNonProxy(Target):
+    pass
+
+
 class Root(models.Model):
     standard_path = models.ManyToManyField(Target, related_name='path')
     proxy_path = models.ManyToManyField(TargetProxy, related_name='proxy')
+    non_proxy_path = models.ManyToManyField(
+        TargetNonProxy, related_name='non_proxy')

--- a/tests/cases/proxy/tests.py
+++ b/tests/cases/proxy/tests.py
@@ -18,3 +18,9 @@ class ProxyModelTestCase(TestCase):
 
         qs = self.tree.query_string_for_field(f, model=TargetProxy)
         self.assertEqual(qs, 'proxy_path__id')
+
+    def test_tree_from_proxy(self):
+        tree = ModelTree(model='proxy.TargetNonProxy')
+        f = TargetProxy._meta.pk
+        qs = tree.query_string_for_field(f, model=TargetProxy)
+        self.assertEqual(qs, 'path__proxy_path__id')

--- a/tests/cases/regressions/issue6/tests.py
+++ b/tests/cases/regressions/issue6/tests.py
@@ -1,11 +1,6 @@
-import django
 from django.test import TestCase
 from modeltree.tree import trees
 from .models import Specimen, Link, Subject
-
-
-get_join_type = lambda: django.VERSION < (1, 5) and \
-    'INNER JOIN' or 'LEFT OUTER JOIN'
 
 
 class Test(TestCase):
@@ -31,7 +26,7 @@ class Test(TestCase):
         self.assertEqual(
             str(qs.query).replace(' ', ''),
             'SELECT "specimen"."ALIQUOT_ID" FROM "specimen" LEFT OUTER JOIN '
-            '"link" ON ("specimen"."ALIQUOT_ID" = "link"."ALIQUOT_ID") {join} '
-            '"subject" ON ("link"."study_id" = "subject"."study_id")'
-            .format(join=get_join_type())
+            '"link" ON ("specimen"."ALIQUOT_ID" = "link"."ALIQUOT_ID") LEFT '
+            'OUTER JOIN "subject" ON ("link"."study_id" = '
+            '"subject"."study_id")'
             .replace(' ', ''))

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -42,11 +42,13 @@ MODELTREES = {
 }
 
 INSTALLED_APPS = (
+    'django.contrib.contenttypes',
     'modeltree',
 
     'tests',
     'tests.cases.core',
     'tests.cases.proxy',
+    'tests.cases.generic',
     'tests.cases.regressions',
 )
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,26 @@
 [flake8]
 
 filename = *.py
+
+[tox]
+envlist =
+    clean,py27-django{18,19},stats
+
+[testenv]
+basepython = python2.7
+
+deps =
+    coverage == 4.0.3
+    django18: Django==1.8.7
+    django19: Django==1.9
+commands = {envbindir}/coverage run -p --omit="*tests*" --source=modeltree --branch test_suite.py
+
+[testenv:clean]
+commands=
+  coverage erase
+
+[testenv:stats]
+commands=
+  coverage combine
+  coverage report
+  coverage html


### PR DESCRIPTION
@bruth This pull request is a work in progress to add Django 1.8+ support for `modeltree`.

I wanted to submit this earlier in an uncompleted state to ask what versions of Django you're interested in supporting.

All django versions below 1.8 have been end-of-lifed with the release of Django 1.9. Would you be comfortable dropping Django 1.7 and below from list of supported versions?  Supporting Django 1.4+ seems to introduce a lot of conditional importing logic, and Django 1.8 introduced some pretty substantial changes to how the ORM works.

## Changes so far
- Added 1.8-1.9 to the travis config and setup file.
- Added a tox.ini file to make it easy to run tests across multiple versions of Django. [Happy to remove this if you'd rather not have it clutter up the repo.]
- Fixed the basic import bugs from deprecations in various versions of Django.

## Still TODO
- [x] Fix remaining test failures

Thanks very much for the work you've put in to this library!