### PR TITLE
Add DCO section to contributing docs

### DIFF
--- a/_posts/2013-07-20-contributing.md
+++ b/_posts/2013-07-20-contributing.md
@@ -10,6 +10,36 @@ The first step in contributing to the code base is [forking the repo](https://he
 
 If you have an existing fork, make the repo is up-to-date. Always create the branch off the actively developed branch (typically `develop` or `master`)
 
+**Before submitting code:**
+First off, thank you for considering a contribution! Before you submit any code, please read the following Developer's Certificate of Origin (DCO):
+
+```
+By making a contribution to the Varify project ("Project"),
+I represent and warrant that:
+
+a. The contribution was created in whole or in part by me and I have the right
+to submit the contribution on my own behalf or on behalf of a third party who
+has authorized me to submit this contribution to the Project; or
+
+b. The contribution is based upon previous work that, to the best of my
+knowledge, is covered under an appropriate open source license and I have the
+right and authorization to submit that work with modifications, whether
+created in whole or in part by me, under the same open source license (unless
+I am permitted to submit under a different license) that I have identified in
+the contribution; or
+
+c. The contribution was provided directly to me by some other person who
+represented and warranted (a) or (b) and I have not modified it.
+
+d. I understand and agree that this Project and the contribution are publicly
+known and that a record of the contribution (including all personal
+information I submit with it, including my sign-off record) is maintained
+indefinitely and may be redistributed consistent with this Project or the open
+source license(s) involved.
+```
+
+This DCO simply certifies that the code you are submitting abides by the clauses stated above. To comply with this agreement, all commits must be signed off with your legal name and email address.
+
 **For bug fixes:**
 
 - Create a branch


### PR DESCRIPTION
@bruth 

All the other repos(Avocado, Serrano, Varify, etc.) have the DCO section in their contributing docs so I figured I'd add it here too. Prompted by #22.

Signed-off-by: Don Naegely <naegelyd@gmail.com>