### PR TITLE
Remove deprecations and add tests

### DIFF
--- a/modeltree/management/commands/modeltree.py
+++ b/modeltree/management/commands/modeltree.py
@@ -1,8 +1,8 @@
 import sys
+from importlib import import_module
 from optparse import NO_DEFAULT, OptionParser
 from django.core.management.base import CommandError, BaseCommand, \
     handle_default_options
-from django.utils.importlib import import_module
 
 
 class Command(BaseCommand):

--- a/modeltree/management/commands/modeltree.py
+++ b/modeltree/management/commands/modeltree.py
@@ -70,7 +70,7 @@ class Command(BaseCommand):
         klass = self.get_subcommand(subcommand)
         # Grab out a list of defaults from the options. optparse does this for
         # us when the script runs from the command line, but since
-        # call_command can be called programatically, we need to simulate the
+        # call_command can be called programmatically, we need to simulate the
         # loading and handling of defaults (see #10080 for details).
         defaults = {}
         for opt in klass.option_list:

--- a/modeltree/tree.py
+++ b/modeltree/tree.py
@@ -195,7 +195,7 @@ class ModelTree(object):
 
         ..the traversal path from ModelA to ModelE is ambiguous. It could
         go from A -> B -> E or A -> C -> D -> E. By default, the shortest
-        path is always choosen to reduce the number of joins necessary, but
+        path is always chosen to reduce the number of joins necessary, but
         if ModelD did not exist..
 
                                 ModelA
@@ -205,7 +205,7 @@ class ModelTree(object):
                                 ModelE
 
         ..both paths only require two joins, thus the path that gets traversed
-        first will only be the choosen one.
+        first will only be the chosen one.
 
         To explicitly choose a path, a route can be defined. Taking the form::
 
@@ -699,7 +699,7 @@ class ModelTree(object):
         return str('__'.join(toks))
 
     def query_condition(self, field, operator, value, model=None):
-        "Conveniece method for constructing a `Q` object for a given field."
+        "Convenience method for constructing a `Q` object for a given field."
         lookup = self.query_string_for_field(field, operator=operator,
                                              model=model)
         return Q(**{lookup: value})

--- a/modeltree/tree.py
+++ b/modeltree/tree.py
@@ -1,5 +1,4 @@
 import inspect
-import warnings
 
 from django.apps import apps
 from django.db import models
@@ -175,15 +174,15 @@ class ModelTreeNode(object):
 class ModelTree(object):
     """A class to handle building and parsing a tree structure given a model.
 
-        `root_model` - The root or "reference" model for the tree. Everything
+        `model` - The root or "reference" model for the tree. Everything
         is relative to the root model.
 
-        `exclude` - A list of models that are to be excluded from this tree.
-        This is typically used to exclude models not intended to be exposed
-        through this API.
+        `excluded_models` - A list of models that are to be excluded from this
+        tree. This is typically used to exclude models not intended to be
+        exposed through this API.
 
-        `routes` - Explicitly defines a join path between two models. Each
-        route is made up of four components. Assuming some model hierarchy
+        `required_routes` - Explicitly defines a join path between two models.
+        Each route is made up of four components. Assuming some model hierarchy
         exists as shown below..
 
                                 ModelA
@@ -246,28 +245,11 @@ class ModelTree(object):
 
     """
     def __init__(self, model=None, **kwargs):
-        if model is None and 'root_model' in kwargs:
-            warnings.warn('The "root_model" key has been renamed to "model"',
-                          DeprecationWarning)
-            model = kwargs.get('root_model')
-
         if not model:
             raise TypeError('No "model" defined')
 
         excluded_models = kwargs.get('excluded_models', ())
         required_routes = kwargs.get('required_routes')
-
-        if not excluded_models and 'exclude' in kwargs:
-            warnings.warn('The "exclude" key has been renamed to '
-                          '"excluded_models"', DeprecationWarning)
-
-            excluded_models = kwargs.get('exclude', ())
-
-        if not required_routes and 'routes' in kwargs:
-            warnings.warn('The "routes" key has been renamed to '
-                          '"required_routes"', DeprecationWarning)
-
-            required_routes = kwargs.get('routes')
 
         excluded_routes = kwargs.get('excluded_routes')
 
@@ -423,15 +405,10 @@ class ModelTree(object):
         targets_seen = set()
 
         for route in routes:
-            if isinstance(route, dict):
-                source_label = route.get('source')
-                target_label = route.get('target')
-                field_label = route.get('field')
-                symmetrical = route.get('symmetrical')
-            else:
-                warnings.warn('Routes are now defined as dicts',
-                              DeprecationWarning)
-                source_label, target_label, field_label, symmetrical = route
+            source_label = route.get('source')
+            target_label = route.get('target')
+            field_label = route.get('field')
+            symmetrical = route.get('symmetrical')
 
             # get models
             source = self.get_model(source_label, local=False)

--- a/modeltree/tree.py
+++ b/modeltree/tree.py
@@ -316,7 +316,7 @@ class ModelTree(object):
             # Attempt to find the model based on the name. Since we don't
             # have the app name, if a model of the same name exists multiple
             # times, we need to throw an error.
-            for app, app_models in apps.app_models.items():
+            for app, app_models in apps.all_models.items():
                 if model_name in app_models:
                     if model is not None:
                         raise ModelNotUnique('The model "{0}" is not unique. '

--- a/modeltree/tree.py
+++ b/modeltree/tree.py
@@ -607,12 +607,12 @@ class ModelTree(object):
 
     def _build(self):
         node = ModelTreeNode(self.root_model)
-        self._root_node = self._find_relations(node)
+        self.root_node = self._find_relations(node)
 
         self._nodes[self.root_model] = {
             'parent': None,
             'depth': 0,
-            'node': self._root_node,
+            'node': self.root_node,
         }
 
         # store local cache of all models in this tree by name
@@ -622,13 +622,6 @@ class ModelTree(object):
 
             self._model_apps.appendlist(model_name, app_name)
             self._models[(app_name, model_name)] = model
-
-    @property
-    def root_node(self):
-        "Returns the `root_node` and implicitly builds the tree."
-        if not hasattr(self, '_root_node'):
-            self._build()
-        return self._root_node
 
     def _node_path_to_model(self, model, node, path=[]):
         "Returns a list representing the path of nodes to the model."

--- a/tests/cases/core/models.py
+++ b/tests/cases/core/models.py
@@ -1,0 +1,9 @@
+from django.db import models
+
+
+class NonUniqueModelName(models.Model):
+    meeting = models.ForeignKey('tests.Meeting')
+
+
+class DisconnectedNonUniqueModelName(models.Model):
+    meeting = models.ForeignKey('tests.Meeting', related_name='+')

--- a/tests/cases/core/tests/test_tree.py
+++ b/tests/cases/core/tests/test_tree.py
@@ -1,7 +1,13 @@
 from django.conf import settings
 from django.test import TestCase
-from modeltree.tree import trees, LazyModelTrees
+from modeltree.tree import LazyModelTrees
+from modeltree.tree import ModelDoesNotExist
+from modeltree.tree import ModelNotRelated
+from modeltree.tree import ModelNotUnique
+from modeltree.tree import ModelTree
+from modeltree.tree import trees
 from tests import models
+from tests.models import A
 
 __all__ = ('LazyTreesTestCase', 'ModelTreeTestCase')
 
@@ -449,3 +455,27 @@ class ModelTreeTestCase(TestCase):
             'JOIN "tests_project" ON ("tests_meeting"."project_id" = '
             '"tests_project"."id")'
             .replace(' ', ''))
+
+    def test_unrelated_model_errors(self):
+        with self.assertRaises(ModelNotRelated):
+            self.office_mt.get_model('tests.A')
+        with self.assertRaises(ModelNotRelated):
+            self.employee_mt.get_model(A)
+        with self.assertRaises(ModelNotRelated):
+            self.employee_mt.get_model('A')
+        with self.assertRaises(ModelDoesNotExist):
+            self.employee_mt.get_model('NotARealModel', local=False)
+        with self.assertRaises(ModelNotUnique):
+            self.employee_mt.get_model('NonUniqueModelName', local=False)
+        with self.assertRaises(ModelNotUnique):
+            self.employee_mt.get_model('NonUniqueModelName', local=True)
+        with self.assertRaises(ModelNotUnique):
+            self.employee_mt.get_model(
+                'DisconnectedNonUniqueModelName', local=False)
+        with self.assertRaises(ModelNotRelated):
+            self.employee_mt.get_model(
+                'DisconnectedNonUniqueModelName', local=True)
+
+    def test_tree_fails_when_given_empty_model_name(self):
+        with self.assertRaises(TypeError):
+            ModelTree(model=None)

--- a/tests/models.py
+++ b/tests/models.py
@@ -12,7 +12,7 @@ class Title(models.Model):
 
 
 class Employee(models.Model):
-    # Different db_column to ensure the corrent name is used
+    # Different db_column to ensure the correct name is used
     first_name = models.CharField(max_length=50, db_column='firstName')
     last_name = models.CharField(max_length=50)
     title = models.ForeignKey(Title)

--- a/tests/models.py
+++ b/tests/models.py
@@ -40,6 +40,14 @@ class Meeting(models.Model):
     end_time = models.DateTimeField()
 
 
+class NonUniqueModelName(models.Model):
+    meeting = models.ForeignKey(Meeting)
+
+
+class DisconnectedNonUniqueModelName(models.Model):
+    meeting = models.ForeignKey(Meeting, related_name='+')
+
+
 # Router Test Models.. no relation to the above models
 # The raw model tree looks like this:
 #        A


### PR DESCRIPTION
@bruth @naegelyd This pull request does some cleanup in preparation for the next final release started in #22.
## Changes
- Corrected spelling of some comments using the `scspell` utility.
- Removed deprecation warnings and support for deprecated behavior.
- Updated docstrings to remove references to deprecations.
- Fixed an import path in a management command to reflect that only python 2.7+ is supported by modern versions of django.
- Added tests for several error conditions.
- Added tests for `excluded_models`.
- Started on additional tests for the `symmetrical` option to `required_routes`.  I'm a little bit stuck here, since the behavior seems counterintuitive or wrong, and wanted to get advice on what the expected behavior is. (I verified that the test also fails on commits prior to #22.)
