### PR TITLE
ModelTree #26 Django 1.10, 1.11 Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ python:
 sudo: false
 
 env:
-    - DJANGO=1.8.7
-    - DJANGO=1.9
+    - DJANGO=1.8.18
+    - DJANGO=1.9.13
+    - DJANGO=1.10.7
+    - DJANGO=1.11.3
 
 before_install:
     - bash bin/check_signoff.sh

--- a/modeltree/__init__.py
+++ b/modeltree/__init__.py
@@ -17,4 +17,5 @@ def get_version(short=False):
                               __version_info__['serial']))
     return ''.join(vers)
 
+
 __version__ = get_version()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ kwargs = {
     'include_package_data': True,
 
     # Dependencies
-    'install_requires': ['django>=1.8,<1.10'],
+    'install_requires': ['django>=1.8,<=1.11'],
 
     'test_suite': 'test_suite',
 

--- a/test_suite.py
+++ b/test_suite.py
@@ -1,10 +1,10 @@
 import os
 import sys
+import django
+from django.core import management
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.settings'
 
-import django
-from django.core import management
 
 django.setup()
 

--- a/tests/cases/core/tests/test_routes.py
+++ b/tests/cases/core/tests/test_routes.py
@@ -1,3 +1,4 @@
+# flake8: noqa: F405
 from django.test import TestCase
 from modeltree.tree import ModelTree
 from tests.models import *  # noqa

--- a/tests/cases/proxy/models.py
+++ b/tests/cases/proxy/models.py
@@ -6,9 +6,9 @@ class OtherModel(models.Model):
 
 
 class Target(models.Model):
-    other_model = models.OneToOneField(OtherModel)
-    m2m = models.ManyToManyField(OtherModel)
-    fk = models.ForeignKey(OtherModel)
+    other_model = models.OneToOneField(OtherModel, related_name="other_model")
+    m2m = models.ManyToManyField(OtherModel, related_name="other_model_m2m")
+    fk = models.ForeignKey(OtherModel, related_name="other_model_fk")
 
 
 class TargetProxy(Target):

--- a/tox.ini
+++ b/tox.ini
@@ -4,15 +4,17 @@ filename = *.py
 
 [tox]
 envlist =
-    clean,py27-django{18,19},stats
+    clean,py27-django{18,19,110,111},stats
 
 [testenv]
 basepython = python2.7
 
 deps =
     coverage == 4.0.3
-    django18: Django==1.8.7
-    django19: Django==1.9
+    django18: Django==1.8.18
+    django19: Django==1.9.13
+    django110: Django==1.10.7
+    django111: Django==1.11.3
 commands = {envbindir}/coverage run -p --omit="*tests*" --source=modeltree --branch test_suite.py
 
 [testenv:clean]


### PR DESCRIPTION
- Updating Django versions, and adding 1.10 and 1.11 to tox file.
- Bumping version in setup.py. Interestingly, with a lower include
  version, tox will still run the 1.10 and 1.11 tests, but still install
  a lower django version.
- Adding related_name to some fields in the `proxy` test models to
  remove system check errors for 1.11.

Signed-off-by: Steven Githens <swgithen@mtu.edu>